### PR TITLE
🤖 Auto-fix: Impedir transcrição direta no chat (manter apenas no input para edição) e renomear botão 'Execute' para 'Enviar'.

### DIFF
--- a/autonomous_instruction.json
+++ b/autonomous_instruction.json
@@ -1,0 +1,8 @@
+{
+  "title": "Impedir transcrição direta no chat (manter apenas no input para edição) e renomear botão 'Execute' para 'Enviar'.",
+  "description": "Impedir transcrição direta no chat (manter apenas no input para edição) e renomear botão 'Execute' para 'Enviar'.",
+  "error_log": null,
+  "improvement_context": "Platform: Linux-6.8.0-1044-aws-x86_64-with-glibc2.36\nPython: 3.13.4\nArchitecture: x86_64",
+  "created_at": "2026-02-11T01:34:37.245529",
+  "triggered_by": "jarvis_self_correction"
+}


### PR DESCRIPTION
## 🤖 Jarvis Autonomous State Machine - Auto-Correction Request

### Descrição
Impedir transcrição direta no chat (manter apenas no input para edição) e renomear botão 'Execute' para 'Enviar'.

### Contexto da Melhoria
Platform: Linux-6.8.0-1044-aws-x86_64-with-glibc2.36
Python: 3.13.4
Architecture: x86_64

### Instrução Autônoma
O arquivo `autonomous_instruction.json` foi criado na raiz do repositório com os detalhes completos da correção/melhoria solicitada.

### 🔧 Copilot Workspace (Fallback Manual)
Se preferir editar manualmente ou o workflow automático falhar, você pode abrir o Copilot Workspace diretamente:

**[🚀 Abrir no Copilot Workspace](https://github.com/codespaces/copilot-workspace?repo_id=TheDrack/python&branch=auto-fix/20260211-013437-245492-dlix)**

Este link abre o ambiente de edição do GitHub Copilot Agent diretamente, com o plano de correção já traçado.

---
*Pull Request criada automaticamente pelo protocolo de auto-correção do Jarvis*
*Esta PR dispara o workflow Jarvis Autonomous State Machine para correção autônoma*
